### PR TITLE
Add log fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ func main() {
 	m.Handle("/", c.Then(func(w http.ResponseWriter, r *http.Request) error {
 		return strudel.NewError("resource not found").
 			WithCode(http.StatusNotFound).
-			WithField("resourceId", "abc123")
+			WithField("resourceId", "abc123").
+			WithLogField("sensitiveId", "cde456")
 	}))
 	h := janice.New(strudel.Recovery, strudel.RequestLogging).Then(janice.Wrap(m))
 	http.ListenAndServe(":8080", h)

--- a/errors.go
+++ b/errors.go
@@ -8,17 +8,19 @@ type (
 
 	// Error represents an error
 	Error struct {
-		msg    string
-		code   int
-		fields Fields
+		msg       string
+		code      int
+		fields    Fields
+		logFields Fields
 	}
 )
 
 // NewError returns a new error
 func NewError(msg string) *Error {
 	return &Error{
-		msg:    msg,
-		fields: Fields{},
+		msg:       msg,
+		fields:    Fields{},
+		logFields: Fields{},
 	}
 }
 
@@ -44,6 +46,22 @@ func (e *Error) WithFields(f Fields) *Error {
 	return e
 }
 
+// WithLogField adds the specified log-only error field
+func (e *Error) WithLogField(key string, value interface{}) *Error {
+	if strings.TrimSpace(key) != "" {
+		e.logFields[key] = value
+	}
+	return e
+}
+
+// WithLogFields adds the specified log-only error fields
+func (e *Error) WithLogFields(f Fields) *Error {
+	for k, v := range f {
+		e.WithLogField(k, v)
+	}
+	return e
+}
+
 // Error returns the error message
 func (e *Error) Error() string {
 	return e.msg
@@ -54,7 +72,19 @@ func (e *Error) Code() int {
 	return e.code
 }
 
-// Fields returns the error fields
+// Fields returns all error fields that are not log-only
 func (e *Error) Fields() Fields {
 	return e.fields
+}
+
+// LogFields returns all error fields including those that are log-only
+func (e *Error) LogFields() Fields {
+	f := make(Fields, len(e.fields)+len(e.logFields))
+	for k, v := range e.fields {
+		f[k] = v
+	}
+	for k, v := range e.logFields {
+		f[k] = v
+	}
+	return f
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -141,3 +141,145 @@ func TestError_WithFields(t *testing.T) {
 		})
 	}
 }
+
+func TestError_WithLogField(t *testing.T) {
+	tests := []struct {
+		name  string
+		err   *strudel.Error
+		key   string
+		value interface{}
+		exp   strudel.Fields
+	}{
+		{
+			name:  "should ignore empty key",
+			err:   strudel.NewError("error"),
+			key:   " \n\t",
+			value: "value",
+			exp:   strudel.Fields{},
+		},
+		{
+			name:  "should set the value",
+			err:   strudel.NewError("error"),
+			key:   "key",
+			value: "value",
+			exp:   strudel.Fields{"key": "value"},
+		},
+		{
+			name:  "should preserve existing values",
+			err:   strudel.NewError("error").WithField("keyA", "valueA"),
+			key:   "keyB",
+			value: "valueB",
+			exp:   strudel.Fields{"keyA": "valueA", "keyB": "valueB"},
+		},
+		{
+			name:  "should overwrite existing keys",
+			err:   strudel.NewError("error").WithField("key", "valueA"),
+			key:   "key",
+			value: "valueB",
+			exp:   strudel.Fields{"key": "valueB"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act := tt.err.WithLogField(tt.key, tt.value).LogFields()
+			if !reflect.DeepEqual(act, tt.exp) {
+				t.Errorf("got %v, expected %v", act, tt.exp)
+			}
+		})
+	}
+}
+
+func TestError_WithLogFields(t *testing.T) {
+	val := &struct{}{}
+	tests := []struct {
+		name   string
+		err    *strudel.Error
+		fields strudel.Fields
+		exp    strudel.Fields
+	}{
+		{
+			name:   "should ignore empty keys",
+			err:    strudel.NewError("error"),
+			fields: strudel.Fields{" \n\t": "valueA", "key": "valueB"},
+			exp:    strudel.Fields{"key": "valueB"},
+		},
+		{
+			name:   "should set the value",
+			err:    strudel.NewError("error"),
+			fields: strudel.Fields{"key": "value"},
+			exp:    strudel.Fields{"key": "value"},
+		},
+		{
+			name:   "should preserve existing values",
+			err:    strudel.NewError("error").WithField("keyA", "valueA"),
+			fields: strudel.Fields{"keyB": "valueB"},
+			exp:    strudel.Fields{"keyA": "valueA", "keyB": "valueB"},
+		},
+		{
+			name:   "should overwrite existing keys",
+			err:    strudel.NewError("error").WithField("key", "valueA"),
+			fields: strudel.Fields{"key": "valueB", "keyC": "valueC"},
+			exp:    strudel.Fields{"key": "valueB", "keyC": "valueC"},
+		},
+		{
+			name:   "should shallow copy fields",
+			err:    strudel.NewError("error"),
+			fields: strudel.Fields{"key": val},
+			exp:    strudel.Fields{"key": val},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act := tt.err.WithLogFields(tt.fields).LogFields()
+			if !reflect.DeepEqual(act, tt.exp) {
+				t.Errorf("got %v, expected %v", act, tt.exp)
+			}
+		})
+	}
+}
+
+func TestError_Fields(t *testing.T) {
+	t.Run("should not include log fields", func(t *testing.T) {
+		exp := strudel.Fields{"field": "value"}
+		act := strudel.NewError("error").
+			WithFields(exp).
+			WithLogField("logField", "value").
+			Fields()
+		if !reflect.DeepEqual(act, exp) {
+			t.Errorf("got %v, expected %v", act, exp)
+		}
+	})
+}
+
+func TestError_LogFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		fields    strudel.Fields
+		logFields strudel.Fields
+		exp       strudel.Fields
+	}{
+		{
+			name:      "should include all fields",
+			fields:    strudel.Fields{"field": "value"},
+			logFields: strudel.Fields{"logField": "value"},
+			exp:       strudel.Fields{"field": "value", "logField": "value"},
+		},
+		{
+			name:      "should use log field value if there is a duplicate key",
+			fields:    strudel.Fields{"field": "fieldValue"},
+			logFields: strudel.Fields{"field": "logFieldValue"},
+			exp:       strudel.Fields{"field": "logFieldValue"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			act := strudel.NewError("error").
+				WithFields(tt.fields).
+				WithLogFields(tt.logFields).
+				LogFields()
+			if !reflect.DeepEqual(act, tt.exp) {
+				t.Errorf("got %v, expected %v", act, tt.exp)
+			}
+		})
+	}
+}

--- a/middleware.go
+++ b/middleware.go
@@ -66,13 +66,15 @@ func ErrorHandling(n janice.HandlerFunc) janice.HandlerFunc {
 					le = le.WithField("code", c)
 				}
 				if c >= 400 && c < 600 {
-					jw.Status(c)
+					jw = jw.Status(c)
 				}
 				if f := err.Fields(); len(f) > 0 {
-					le = le.WithField("data", f)
-					jw.Data(f)
+					jw = jw.Data(f)
 				}
-				jw.Message(err.Error())
+				if lf := err.LogFields(); len(lf) > 0 {
+					le = le.WithField("data", lf)
+				}
+				jw = jw.Message(err.Error())
 			}
 			le.Error(err.Error())
 			_, err := jw.Send()

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -254,7 +254,7 @@ func TestErrorHandling(t *testing.T) {
 			},
 		},
 		{
-			name: "should write error fields",
+			name: "should write error fields to log and body",
 			err:  strudel.NewError("error").WithField("key", "value"),
 			code: http.StatusInternalServerError,
 			body: map[string]interface{}{
@@ -267,6 +267,22 @@ func TestErrorHandling(t *testing.T) {
 				"level": "error",
 				"msg":   "error",
 				"data":  map[string]interface{}{"key": "value"},
+			},
+		},
+		{
+			name: "should not write error log fields to body",
+			err:  strudel.NewError("error").WithField("field", "value").WithLogField("logField", "value"),
+			code: http.StatusInternalServerError,
+			body: map[string]interface{}{
+				"status":  "error",
+				"message": "error",
+				"data":    map[string]interface{}{"field": "value"},
+			},
+			log: map[string]interface{}{
+				"type":  "error",
+				"level": "error",
+				"msg":   "error",
+				"data":  map[string]interface{}{"field": "value", "logField": "value"},
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds the concept of 'log fields' to `Error`. This is for the situation where data should be logged, but not exposed to clients via the response body.