### PR TITLE
Add request tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ func main() {
 			WithField("resourceId", "abc123").
 			WithLogField("sensitiveId", "cde456")
 	}))
-	h := janice.New(strudel.Recovery, strudel.RequestLogging).Then(janice.Wrap(m))
+	h := janice.New(strudel.RequestTracking, strudel.Recovery, strudel.RequestLogging).Then(janice.Wrap(m))
 	http.ListenAndServe(":8080", h)
 }
 ```


### PR DESCRIPTION
Adds a new `RequestTracking` middleware func that stores a unique ID in the request context. Adding the middleware to the chain allows wrapped functions to log the ID, enabling tracking of requests and error logs.