### PR TITLE
Log integer response values correctly

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -3,7 +3,6 @@ package strudel
 import (
 	"context"
 	"net/http"
-	"strconv"
 
 	"github.com/felixge/httpsnoop"
 	"github.com/gamegos/jsend"
@@ -57,7 +56,7 @@ func RequestLogging(n janice.HandlerFunc) janice.HandlerFunc {
 			"path":     p,
 			"code":     m.Code,
 			"duration": m.Duration.String(),
-			"written":  strconv.FormatInt(m.Written, 10),
+			"written":  m.Written,
 		})
 		if rid, ok := GetRequestID(r); ok {
 			le = le.WithField("request", rid)

--- a/middleware.go
+++ b/middleware.go
@@ -55,7 +55,7 @@ func RequestLogging(n janice.HandlerFunc) janice.HandlerFunc {
 			"host":     r.Host,
 			"method":   r.Method,
 			"path":     p,
-			"code":     strconv.Itoa(m.Code),
+			"code":     m.Code,
 			"duration": m.Duration.String(),
 			"written":  strconv.FormatInt(m.Written, 10),
 		})

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -58,7 +58,7 @@ func TestRequestLogging(t *testing.T) {
 				"method":  "GET",
 				"host":    "example.com",
 				"path":    "/path",
-				"code":    "500",
+				"code":    500,
 			},
 			err: err,
 		},
@@ -76,7 +76,7 @@ func TestRequestLogging(t *testing.T) {
 				"method":  "GET",
 				"host":    "example.com",
 				"path":    "/path",
-				"code":    "301",
+				"code":    301,
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func TestRequestLogging(t *testing.T) {
 				"method":  "POST",
 				"host":    "example.com",
 				"path":    "/path",
-				"code":    "201",
+				"code":    201,
 			},
 		},
 	}
@@ -112,6 +112,9 @@ func TestRequestLogging(t *testing.T) {
 					if buf.Len() > 0 {
 						if err = json.Unmarshal(buf.Bytes(), &act); err != nil {
 							t.Errorf("got %v, expected nil", err)
+						}
+						if c, ok := act["code"]; ok {
+							act["code"] = int(c.(float64))
 						}
 					}
 					for k, v := range tt.exp {


### PR DESCRIPTION
This PR updates `RequestLogging` middleware to log the `code` and `written` fields as `int` and `int64` types respectively. This ensures consistency with `ErrorHandling` middleware.